### PR TITLE
Add option to fetch dependencies in a recursive manner

### DIFF
--- a/include/pkg/dependency_loader.h
+++ b/include/pkg/dependency_loader.h
@@ -25,7 +25,8 @@ public:
 
   void retrieve(
       boost::filesystem::path const&,
-      iteration_fn_t const& = [](dep*, branch_commit const&) {});
+      iteration_fn_t const& = [](dep*, branch_commit const&) {},
+      bool recursive = false);
 
   dep* root();
   std::vector<dep*> sorted();

--- a/include/pkg/load_deps.h
+++ b/include/pkg/load_deps.h
@@ -6,6 +6,6 @@ namespace pkg {
 
 void load_deps(boost::filesystem::path const& repo,
                boost::filesystem::path const& deps_root, bool clone_https,
-               bool force);
+               bool force, bool recursive);
 
 }  // namespace pkg

--- a/src/load_deps.cc
+++ b/src/load_deps.cc
@@ -25,7 +25,7 @@ namespace fs = boost::filesystem;
 namespace pkg {
 
 void load_deps(fs::path const& repo, fs::path const& deps_root,
-               bool const clone_https, bool const force) {
+               bool const clone_https, bool const force, bool const recursive) {
   if (!boost::filesystem::is_directory(deps_root)) {
     boost::filesystem::create_directories(deps_root);
   }
@@ -78,7 +78,7 @@ void load_deps(fs::path const& repo, fs::path const& deps_root,
   auto repeat = false;
   do {
     repeat = false;
-    l.retrieve(repo, iterator);
+    l.retrieve(repo, iterator, recursive);
     for (auto const& d : l.get_all()) {
       if (d->url_ == ROOT || d->commit_ == get_commit(d->path_)) {
         continue;

--- a/src/main.cc
+++ b/src/main.cc
@@ -23,6 +23,7 @@ int main(int argc, char** argv) {
         "  -l [-h]   load    [clone dependencies\n"
         "                     -h for https (default: ssh);\n"
         "                     -f for hard reset (default: checkout)]\n"
+        "                     -r for recursive (default: false)]\n"
         "  -u        update  [recursive on new commit]\n"
         "  -s        status  [print status]\n"
         "  -r        resolve [resolve conflicts]\n"
@@ -38,7 +39,8 @@ int main(int argc, char** argv) {
     } else if (std::strcmp(argv[1], "-l") == 0) {
       load_deps(fs::path{"."}, fs::path("deps"),
                 argc > 2 && std::strcmp(argv[2], "-h") == 0,
-                argc > 3 && std::strcmp(argv[3], "-f") == 0);
+                argc > 3 && std::strcmp(argv[3], "-f") == 0,
+                argc > 4 && std::strcmp(argv[4], "-r") == 0);
     } else if (std::strcmp(argv[1], "-s") == 0) {
       print_status(fs::path{"."}, fs::path("deps"));
     } else if (std::strcmp(argv[1], "-r") == 0) {

--- a/src/print_status.cc
+++ b/src/print_status.cc
@@ -24,8 +24,8 @@ void print_status(std::vector<dep*> const& all) {
     if (s.commited_change_ || s.recursive_change_) {
       auto const color = s.commited_change_ && s.recursive_change_
                              ? fmt::terminal_color::magenta
-                             : s.commited_change_ ? fmt::terminal_color::red
-                                                  : fmt::terminal_color::blue;
+                         : s.commited_change_ ? fmt::terminal_color::red
+                                              : fmt::terminal_color::blue;
       fmt::print(fg(color), "{:>{}}{}", name, indent * 2 + name.length(),
                  s.uncommited_change_ ? "*" : "");
     } else {


### PR DESCRIPTION
In case of having some libs in your app that depends on third party external components add option to recursively parse project folder to search for .pkg files that are not in root folder of the project.

This will reduce the size of the main .pkg file and clarify a bit what lib depends on what.

![image](https://user-images.githubusercontent.com/1428537/101214490-c85c3080-3684-11eb-9fed-be1afa150e1e.png)
