### PR TITLE
Replace deprecated action in workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -71,13 +71,13 @@ jobs:
 
       # ==== DISTRIBUTION ====
       - name: Upload Distribution
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pkg-linux-${{ matrix.config.target }}
           path: ./build/pkg
 
       - name: Upload Distribution (Legacy Naming)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pkg
           path: ./build/pkg

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,13 +33,13 @@ jobs:
 
       # ==== DISTRIBUTION ====
       - name: Upload Distribution
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pkg-macos-amd64
           path: ./build/pkg
 
       - name: Upload Distribution (Legacy Naming)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pkgosx
           path: ./build/pkg

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload Distribution
         if: matrix.mode == 'Release'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: pkg
           path: ./build/pkg.exe


### PR DESCRIPTION
The pipeline seems to fail due to the usage of a deprecated GitHub upload artifact action version, so this should fix that particular issue.