### PR TITLE
Use https by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ configure_file(
         ${CMAKE_BINARY_DIR}/generated/test_dir.h
 )
 file(GLOB_RECURSE pkg-test-files test/*_test.cc)
-add_executable(pkg-test EXCLUDE_FROM_ALL src/read_deps.cc ${pkg-test-files})
+add_executable(pkg-test EXCLUDE_FROM_ALL src/read_deps.cc src/git.cc ${pkg-test-files})
 target_include_directories(pkg-test PRIVATE ${CMAKE_BINARY_DIR}/generated)
 target_link_libraries(pkg-test pkglib)
 set_property(TARGET pkg-test PROPERTY CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,11 @@ target_link_libraries(pkglib
 if (MSVC)
     target_link_libraries(pkglib Userenv.lib)
 endif ()
-target_compile_features(pkglib PUBLIC cxx_std_17)
+target_compile_features(pkglib PUBLIC cxx_std_20)
 
 add_executable(pkg src/main.cc)
 target_link_libraries(pkg pkglib)
-target_compile_features(pkg PRIVATE cxx_std_17)
+target_compile_features(pkg PRIVATE cxx_std_20)
 if ("${CMAKE_BUILD_TYPE}" STREQUAL Release AND NOT MSVC)
     add_custom_command(
             TARGET pkg

--- a/include/pkg/git.h
+++ b/include/pkg/git.h
@@ -18,9 +18,9 @@ struct commit_info {
   branch_commit bc_;
 };
 
-enum Protocol { Ssh, Https };
+enum protocol { kSsh, kHttps };
 
-std::string url_to_protocol(std::string url, Protocol protocol);
+std::string url_to_protocol(std::string url, protocol);
 
 std::string git_shorten(dep const*, std::string const& commit);
 

--- a/include/pkg/git.h
+++ b/include/pkg/git.h
@@ -18,7 +18,9 @@ struct commit_info {
   branch_commit bc_;
 };
 
-std::string ssh_to_https(std::string url);
+enum Protocol { Ssh, Https };
+
+std::string url_to_protocol(std::string url, Protocol protocol);
 
 std::string git_shorten(dep const*, std::string const& commit);
 

--- a/src/git.cc
+++ b/src/git.cc
@@ -13,21 +13,54 @@
 
 namespace pkg {
 
-std::string ssh_to_https(std::string url) {
-  if (!utl::cstr{url.c_str(), url.size()}.starts_with("git")) {
+std::string normalize_url(std::string url) {
+  if (url.starts_with("ssh://") || url.starts_with("https://") ||
+      url.starts_with("http://")) {
     return url;
-  } else if (auto const colon_pos = url.find_last_of(':');
-             colon_pos == std::string::npos) {
-    return url;
-  } else {
+  }
+
+  auto const at_pos = url.find("@");
+  auto const colon_pos = url.find(":");
+
+  // Try to detect urls in the form username@ssh-server:path
+  if (at_pos != std::string::npos && colon_pos != std::string::npos &&
+      at_pos < colon_pos) {
     // Replace ":" -> "/"
     url[colon_pos] = '/';
 
     // Replace git@ -> https://
-    url = "https://" + url.substr(4);
-
-    return url;
+    return "ssh://" + url;
   }
+
+  // Give up and hope for the best
+  return url;
+}
+
+std::string url_to_protocol(std::string url, Protocol protocol) {
+  auto const normalized_url = normalize_url(url);
+
+  auto const protocol_len = normalized_url.find("://");
+  auto const without_protocol = normalized_url.substr(protocol_len + 3);
+
+  switch (protocol) {
+    case Protocol::Https: {
+      auto const username_pos = without_protocol.find('@');
+      if (username_pos != std::string::npos) {
+        return "https://" + without_protocol.substr(username_pos + 1);
+      } else {
+        return "https://" + without_protocol;
+      }
+    }
+    case Protocol::Ssh: {
+      if (without_protocol.contains('@')) {
+        return "ssh://" + without_protocol;
+      } else {
+        return "ssh://git@" + without_protocol;
+      }
+    }
+  }
+
+  return url;
 }
 
 std::string git_shorten(dep const* d, std::string const& commit) {
@@ -78,8 +111,12 @@ void git_clone(executor& e, dep const* d, bool const to_https) {
   }
 
   e.exec(d->path_.parent_path(), "git clone {} {}",
-         to_https ? ssh_to_https(d->url_) : d->url_,
+         url_to_protocol(d->url_, to_https ? Protocol::Https : Protocol::Ssh),
          boost::filesystem::absolute(d->path_).string());
+  if (to_https) {
+    e.exec(d->path_, "git remote set-url --push origin {}",
+           url_to_protocol(d->url_, Protocol::Ssh));
+  }
   e.exec(d->path_, "git checkout {}", d->commit_);
   e.exec(d->path_, "git submodule update --init --recursive");
 }

--- a/src/git.cc
+++ b/src/git.cc
@@ -36,14 +36,14 @@ std::string normalize_url(std::string url) {
   return url;
 }
 
-std::string url_to_protocol(std::string url, Protocol protocol) {
+std::string url_to_protocol(std::string url, protocol const p) {
   auto const normalized_url = normalize_url(url);
 
   auto const protocol_len = normalized_url.find("://");
   auto const without_protocol = normalized_url.substr(protocol_len + 3);
 
-  switch (protocol) {
-    case Protocol::Https: {
+  switch (p) {
+    case protocol::kHttps: {
       auto const username_pos = without_protocol.find('@');
       if (username_pos != std::string::npos) {
         return "https://" + without_protocol.substr(username_pos + 1);
@@ -51,7 +51,7 @@ std::string url_to_protocol(std::string url, Protocol protocol) {
         return "https://" + without_protocol;
       }
     }
-    case Protocol::Ssh: {
+    case protocol::kSsh: {
       if (without_protocol.contains('@')) {
         return "ssh://" + without_protocol;
       } else {
@@ -111,11 +111,11 @@ void git_clone(executor& e, dep const* d, bool const to_https) {
   }
 
   e.exec(d->path_.parent_path(), "git clone {} {}",
-         url_to_protocol(d->url_, to_https ? Protocol::Https : Protocol::Ssh),
+         url_to_protocol(d->url_, to_https ? protocol::kHttps : protocol::kSsh),
          boost::filesystem::absolute(d->path_).string());
   if (to_https) {
     e.exec(d->path_, "git remote set-url --push origin {}",
-           url_to_protocol(d->url_, Protocol::Ssh));
+           url_to_protocol(d->url_, protocol::kSsh));
   }
   e.exec(d->path_, "git checkout {}", d->commit_);
   e.exec(d->path_, "git submodule update --init --recursive");

--- a/src/load_deps.cc
+++ b/src/load_deps.cc
@@ -44,11 +44,11 @@ void load_deps(fs::path const& repo, fs::path const& deps_root,
           std::cout << std::flush;
           e.exec(d->path_, "git remote set-url origin {}",
                  url_to_protocol(
-                     d->url_, clone_https ? Protocol::Https : Protocol::Ssh));
+                     d->url_, clone_https ? protocol::kHttps : protocol::kSsh));
           if (clone_https) {
             // Push needs to use ssh even with http
             e.exec(d->path_, "git remote set-url --push origin {}",
-                   url_to_protocol(d->url_, Protocol::Ssh));
+                   url_to_protocol(d->url_, protocol::kSsh));
           }
           e.exec(d->path_, "git fetch origin");
         }

--- a/src/load_deps.cc
+++ b/src/load_deps.cc
@@ -43,7 +43,13 @@ void load_deps(fs::path const& repo, fs::path const& deps_root,
           fmt::print("{}: fetch\n", d->name());
           std::cout << std::flush;
           e.exec(d->path_, "git remote set-url origin {}",
-                 clone_https ? ssh_to_https(d->url_) : d->url_);
+                 url_to_protocol(
+                     d->url_, clone_https ? Protocol::Https : Protocol::Ssh));
+          if (clone_https) {
+            // Push needs to use ssh even with http
+            e.exec(d->path_, "git remote set-url --push origin {}",
+                   url_to_protocol(d->url_, Protocol::Ssh));
+          }
           e.exec(d->path_, "git fetch origin");
         }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -11,7 +11,7 @@ using namespace pkg;
 
 extern bool verbose;
 
-bool has_flag(const std::span<char*> args, char const* str) {
+bool has_flag(std::span<char*> args, char const* str) {
   return std::any_of(args.begin(), args.end(),
                      [&](char* arg) { return std::strcmp(arg, str) == 0; });
 }
@@ -35,8 +35,8 @@ int main(int argc, char** argv) {
     return 0;
   }
 
-  const auto https = has_flag(args, "-h");
-  const auto ssh = has_flag(args, "--ssh");
+  auto const https = has_flag(args, "-h");
+  auto const ssh = has_flag(args, "--ssh");
   if (https && ssh) {
     fmt::println(stderr, "-h and --ssh cannot be used at the same time.");
     return 1;

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,5 +1,6 @@
 #include <cstdio>
 #include <algorithm>
+#include <span>
 
 #include "pkg/exec.h"
 #include "pkg/load_deps.h"
@@ -10,21 +11,23 @@ using namespace pkg;
 
 extern bool verbose;
 
-bool has_flag(int argc, char** argv, char const* str) {
-  return std::any_of(argv, argv + argc,
+bool has_flag(const std::span<char*> args, char const* str) {
+  return std::any_of(args.begin(), args.end(),
                      [&](char* arg) { return std::strcmp(arg, str) == 0; });
 }
 
 int main(int argc, char** argv) {
-  if (argc < 2 || has_flag(argc - 1, argv + 1, "--help")) {
+  auto const args = std::span(argv + 1, argc - 1);
+  if (argc < 2 || has_flag(args, "--help")) {
     printf(
         "Usage:\n"
         "  pkg load | -l      [clone dependencies]\n"
-        "      -h          for https        (default: ssh);\n"
-        "      -f          for hard reset   (default: checkout)]\n"
-        "      -r          for recursive    (default: false)]\n"
+        "      -h          for https        (default: ssh)\n"
+        "      -f          for hard reset   (default: checkout)\n"
+        "      -r          for recursive    (default: false)\n"
         "      --drop-wip  check out ref from .pkg even though there are\n"
         "                  unpushed changes (default: false)\n"
+        "      --ssh       Clone using ssh  (default: https)\n"
         "  pkg status | -s    [print status]\n"
         "\n"
         "Common flags - apply everywhere:\n"
@@ -32,19 +35,26 @@ int main(int argc, char** argv) {
     return 0;
   }
 
+  const auto https = has_flag(args, "-h");
+  const auto ssh = has_flag(args, "--ssh");
+  if (https && ssh) {
+    fmt::println(stderr, "-h and --ssh cannot be used at the same time.");
+    return 1;
+  }
+
   try {
     auto const mode = std::string_view{argv[1]};
-    set_verbose(has_flag(argc - 1, argv + 1, "-v"));
+    set_verbose(has_flag(args, "-v"));
     if (mode == "load" || mode == "-l") {
       load_deps(fs::path{"."}, fs::path("deps"),  //
-                has_flag(argc - 1, argv + 1, "-h"),  //
-                has_flag(argc - 1, argv + 1, "-f"),  //
-                has_flag(argc - 1, argv + 1, "-r"),  //
-                has_flag(argc - 1, argv + 1, "--drop-wip"));
+                !ssh,  //
+                has_flag(args, "-f"),  //
+                has_flag(args, "-r"),  //
+                has_flag(args, "--drop-wip"));
     } else if (mode == "status" || mode == "-s") {
       print_status(fs::path{"."}, fs::path("deps"));
     } else {
-      fmt::println("Unknown mode {}. See pkg --help for usage.", mode);
+      fmt::println(stderr, "Unknown mode {}. See pkg --help for usage.", mode);
     }
   } catch (std::exception const& e) {
     std::cerr << "error: " << e.what() << "\n";

--- a/test/url_test.cc
+++ b/test/url_test.cc
@@ -6,36 +6,36 @@ using pkg::url_to_protocol;
 
 TEST_CASE("to ssh") {
   CHECK(url_to_protocol("https://github.com/motis-project/pkg",
-                        pkg::Protocol::Ssh) ==
+                        pkg::protocol::kSsh) ==
         "ssh://git@github.com/motis-project/pkg");
 
   CHECK(url_to_protocol("ssh://git@github.com/motis-project/pkg",
-                        pkg::Protocol::Ssh) ==
+                        pkg::protocol::kSsh) ==
         "ssh://git@github.com/motis-project/pkg");
 
   CHECK(url_to_protocol("git://github.com/motis-project/pkg",
-                        pkg::Protocol::Ssh) ==
+                        pkg::protocol::kSsh) ==
         "ssh://git@github.com/motis-project/pkg");
 
-  CHECK(
-      url_to_protocol("git@github.com:motis-project/pkg", pkg::Protocol::Ssh) ==
-      "ssh://git@github.com/motis-project/pkg");
+  CHECK(url_to_protocol("git@github.com:motis-project/pkg",
+                        pkg::protocol::kSsh) ==
+        "ssh://git@github.com/motis-project/pkg");
 }
 
 TEST_CASE("to https") {
   CHECK(url_to_protocol("https://github.com/motis-project/pkg",
-                        pkg::Protocol::Https) ==
+                        pkg::protocol::kHttps) ==
         "https://github.com/motis-project/pkg");
 
   CHECK(url_to_protocol("ssh://git@github.com/motis-project/pkg",
-                        pkg::Protocol::Https) ==
+                        pkg::protocol::kHttps) ==
         "https://github.com/motis-project/pkg");
 
   CHECK(url_to_protocol("git://github.com/motis-project/pkg",
-                        pkg::Protocol::Https) ==
+                        pkg::protocol::kHttps) ==
         "https://github.com/motis-project/pkg");
 
   CHECK(url_to_protocol("git@github.com:motis-project/pkg",
-                        pkg::Protocol::Https) ==
+                        pkg::protocol::kHttps) ==
         "https://github.com/motis-project/pkg");
 }

--- a/test/url_test.cc
+++ b/test/url_test.cc
@@ -1,0 +1,41 @@
+#include "doctest.h"
+
+#include "pkg/git.h"
+
+using pkg::url_to_protocol;
+
+TEST_CASE("to ssh") {
+  CHECK(url_to_protocol("https://github.com/motis-project/pkg",
+                        pkg::Protocol::Ssh) ==
+        "ssh://git@github.com/motis-project/pkg");
+
+  CHECK(url_to_protocol("ssh://git@github.com/motis-project/pkg",
+                        pkg::Protocol::Ssh) ==
+        "ssh://git@github.com/motis-project/pkg");
+
+  CHECK(url_to_protocol("git://github.com/motis-project/pkg",
+                        pkg::Protocol::Ssh) ==
+        "ssh://git@github.com/motis-project/pkg");
+
+  CHECK(
+      url_to_protocol("git@github.com:motis-project/pkg", pkg::Protocol::Ssh) ==
+      "ssh://git@github.com/motis-project/pkg");
+}
+
+TEST_CASE("to https") {
+  CHECK(url_to_protocol("https://github.com/motis-project/pkg",
+                        pkg::Protocol::Https) ==
+        "https://github.com/motis-project/pkg");
+
+  CHECK(url_to_protocol("ssh://git@github.com/motis-project/pkg",
+                        pkg::Protocol::Https) ==
+        "https://github.com/motis-project/pkg");
+
+  CHECK(url_to_protocol("git://github.com/motis-project/pkg",
+                        pkg::Protocol::Https) ==
+        "https://github.com/motis-project/pkg");
+
+  CHECK(url_to_protocol("git@github.com:motis-project/pkg",
+                        pkg::Protocol::Https) ==
+        "https://github.com/motis-project/pkg");
+}


### PR DESCRIPTION
I also included making the url mangling code able to handle all three common url formats. Previously it was assumed that if the url was not in ssh format, it was already okay, since it could only convert from ssh -> http.
Since we now also have to handle the opposite direction with the `--ssh` flag, this is probably useful.
It should now be able to handle:
* `https://github.com/motis-project/pkg`
* `ssh://git@github.com/motis-project/pkg`
* `git@github.com:motis-project/pkg`